### PR TITLE
Revised tutorial based on Dr. Mobley's comments

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -452,9 +452,9 @@ In this section, we will use the wrapper `ever_given` to run the docking contain
 
 
 # Building Your Own Docking Container
-* For more detailed information about container requirements, please see [ContainerRequirements.md](https://github.com/samplchallenges/SAMPL-containers/blob/tutorial/tutorials/ContainerRequirements.md)
-* For an example template of a container directory, please see [SAMPL-containers/tutorial/template/](https://github.com/samplchallenges/SAMPL-containers/tree/tutorial/tutorials/template)
-* For more information on how to build your own conda environment inside a container, please see [CondaEnvInstructions.pdf](https://github.com/samplchallenges/SAMPL-containers/blob/tutorial/tutorials/CondaEnvInstructions.pdf)
+* For more detailed information about container requirements, please see [ContainerRequirements.md](https://github.com/samplchallenges/SAMPL-containers/blob/tutorial/tutorials/ContainerRequirements.md).
+* For an example template of a container directory, please see [SAMPL-containers/tutorial/template/](https://github.com/samplchallenges/SAMPL-containers/tree/tutorial/tutorials/template).
+* For more information on how to build your own conda environment inside a container, please see [CondaEnvInstructions.pdf](https://github.com/samplchallenges/SAMPL-containers/blob/tutorial/tutorials/CondaEnvInstructions.pdf).
 
 
 # Other Important Information


### PR DESCRIPTION
2.4.2-2.4.3: Why is step 3 separate rather than just something you copy and paste in step 2?
I initially put the steps separate because: 
Step 3 to illustrate this is where we’re specifying the inheritance
Step 4 to illustrate this is where you need to change filenames to fit your own
Step 5 to illustrate the entry point needs to be the same as the previous section

Please let me know if this isn't being conveyed and I'm happy to change it to just a single copy and paste step